### PR TITLE
Fixes that should make the benchmark work

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -28,8 +28,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v3
 
-      - name: Isolate repo link to env.USER_REPO
-        run: bash .github/repo_regex.sh "${{ github.event.issue.body }}" "${{ github.event.issue.user.login }}"
+      - name: Isolate repo link
+        run: |
+          repository=$(<<< "${{ github.event.issue.body }}" grep -Po 'github.com/[[[:alnum:]._-]+/\K[[:alnum:]._-]+' | sed -E 's/.git$//')
+          echo "USER_REPO=${{ github.event.issue.user.login }}/$repository" >> $GITHUB_ENV
         continue-on-error: true
 
 # First check | id: repo_check --N-> invites_check

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,8 @@ ENV WORLD_PATH=${WORLD_PATH}
 
 RUN apt-get update
 RUN apt-get install -y python3-pip
-RUN pip3 install numpy
+# need opencv for the simulation server (numpy is included in opencv)
+RUN pip3 install opencv-python
 
 # If called with no arguments, launch in headless mode
 # (for instance, on the simulation server of webots.cloud, the GUI is launched to stream it to the user and a different command is used)

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 </span>
 
 <!-- This is the shield badge where you can replace the webots.cloud link in brackets with your personal webots.cloud page -->
-[![webots.cloud - Benchmark](https://img.shields.io/badge/webots.cloud-Benchmark-007ACC)](
-https://benchmark.webots.cloud/run?version=R2023a&url=https://github.com/stefaniapedrazzi/openai-gym-benchmark/blob/main/worlds/visual_tracking.wbt&type=benchmark)
+[![webots.cloud - Benchmark](https://img.shields.io/badge/webots.cloud-Benchmark-007ACC)](https://benchmark.webots.cloud/run?version=R2023a&url=https://github.com/stefaniapedrazzi/openai-gym-benchmark/blob/main/worlds/visual_tracking.wbt&type=benchmark)
 
 <!-- TODO: add examples when available
 ## Benchmark examples

--- a/controllers/visual_tracking_benchmark/visual_tracking_benchmark.py
+++ b/controllers/visual_tracking_benchmark/visual_tracking_benchmark.py
@@ -10,15 +10,6 @@ import numpy as np
 import os
 import sys
 
-try:
-    sys.path.append(os.path.join(os.path.normpath(os.environ.get("WEBOTS_HOME")), 'projects', 'samples', 'robotbenchmark',
-                                 'include'))
-    from robotbenchmark import robotbenchmarkRecord
-except ImportError:
-    sys.stderr.write("Warning: 'robotbenchmark' module not found.\n")
-    sys.exit(0)
-
-
 def normalize(v):
     """Return normalized 3D vector v."""
     det = math.sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2])
@@ -210,18 +201,11 @@ else:
     hitRate = float(hitsCount) / stepsCount
 
 robot.wwiSendText("stop")
-
-# Wait for record message.
-timestep = int(robot.getBasicTimeStep())
-while robot.step(timestep) != -1:
-    message = robot.wwiReceiveText()
-    while message:
-        if message.startswith("record:"):
-            record = robotbenchmarkRecord(message, "visual_tracking", hitRate)
-            robot.wwiSendText(record)
-            break
-        elif message == "exit":
-            break
-        message = robot.wwiReceiveText()
+# Performance output used by automated CI script
+CI = os.environ.get("CI")
+if CI:
+    print(f"performance:{hitRate}")
+else:
+    print(f"Final hit rate: {hitRate:.2f}")
 
 robot.simulationSetMode(Supervisor.SIMULATION_MODE_PAUSE)

--- a/worlds/visual_tracking.wbt
+++ b/worlds/visual_tracking.wbt
@@ -29,6 +29,7 @@ AiboErs7 {
   rotation 0.01708188509204869 -0.7223048238922644 -0.6913638337255336 -0.068192399
   controller "visual_tracking"
   window "pan_tilt_camera_view"
+  synchronization FALSE
   camera_width 480
   camera_height 320
   headSlot [


### PR DESCRIPTION
Here are the modifications I did:

- I added opencv in the webots container as it is the one used on the simulation server, which will run the default controller locally so it need its dependencies (I should explain it better in the instructions)
- the supervisor must print the score in the "performance:SCORE" format to tell the automated script that the benchmark finished correctly
- it's better if the robot is set as not synchronized in the world file just in case the participant's controller never calls robot.step() and would stall evaluation (I didn't find any elegant solution to remedy this, I should think about it more)
- I use a regex to fetch the link in the README badge to get the link to the leaderboard and I didn't expect it to be multiline which is a correct markdown syntax. I'll see if I can fix the regex

\+ I added the other regex fix to ignore .git if it is at the end of the registration link
\+ removed the robotbenchmark functions